### PR TITLE
Fix premature draw state on new matches

### DIFF
--- a/src/components/layout/GameRoom.tsx
+++ b/src/components/layout/GameRoom.tsx
@@ -3,9 +3,12 @@ import { resolveServerUrl, createClient } from '../../lib/client';
 import { MatchLobby } from '../ui/MatchLobby';
 import { useMatchManager } from '../../hooks/useMatchManager';
 
+type StoredSession = { matchID: string; playerID: string; credentials: string };
+
 interface GameRoomProps {
-  storedSession: { matchID: string; playerID: string; credentials: string } | null;
-  storeSession: (session: { matchID: string; playerID: string; credentials: string } | null) => void;
+  storedSession: StoredSession | null;
+  // eslint-disable-next-line no-unused-vars
+  storeSession: (session: StoredSession | null) => void;
 }
 
 export const GameRoom = ({ storedSession, storeSession }: GameRoomProps) => {

--- a/src/components/ui/MatchLobby.tsx
+++ b/src/components/ui/MatchLobby.tsx
@@ -3,8 +3,10 @@ import type { PlayerID } from '../../types';
 
 interface MatchLobbyProps {
   matchID: string;
+  // eslint-disable-next-line no-unused-vars
   setMatchID: (id: string) => void;
   playerID: PlayerID;
+  // eslint-disable-next-line no-unused-vars
   setPlayerID: (id: PlayerID) => void;
   statusMessage: string;
   isLoading: boolean;

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -56,9 +56,11 @@ export const GridSkirmish: Game<GameState> = {
   },
   turn: {
     onBegin: (state, ctx) => {
-      resetTurnFlags(state.units, ctx.currentPlayer as PlayerID);
+      if (!ctx) return;
+      const currentPlayer = ctx.currentPlayer as PlayerID;
+      resetTurnFlags(state.units, currentPlayer);
       cleanupSelection(state);
-      pushLog(state, `Player ${Number(ctx.currentPlayer) + 1}'s command phase.`);
+      pushLog(state, `Player ${Number(currentPlayer) + 1}'s command phase.`);
     },
     onEnd: (state) => {
       state.selectedCharacterId = null;
@@ -123,6 +125,7 @@ export const GridSkirmish: Game<GameState> = {
     }
   },
   endIf: (state) => {
+    const totalUnits = listUnits(state).length;
     const remaining = {
       '0': aliveUnits(state, '0').length,
       '1': aliveUnits(state, '1').length
@@ -131,9 +134,13 @@ export const GridSkirmish: Game<GameState> = {
     console.log('endIf check:', {
       player0Units: remaining['0'],
       player1Units: remaining['1'],
-      totalUnits: listUnits(state).length,
+      totalUnits,
       units: Object.keys(state.units || {})
     });
+
+    if (totalUnits === 0) {
+      return undefined;
+    }
 
     if (remaining['0'] === 0 && remaining['1'] === 0) {
       return { draw: true };

--- a/src/game/helpers/index.ts
+++ b/src/game/helpers/index.ts
@@ -19,6 +19,7 @@ export const cleanupSelection = (state: GameState) => {
 };
 
 export const checkGameEnd = (state: GameState) => {
+  const totalUnits = listUnits(state).length;
   const remaining = {
     '0': aliveUnits(state, '0').length,
     '1': aliveUnits(state, '1').length
@@ -27,9 +28,18 @@ export const checkGameEnd = (state: GameState) => {
   console.log('endIf check:', {
     player0Units: remaining['0'],
     player1Units: remaining['1'],
-    totalUnits: listUnits(state).length,
+    totalUnits,
     units: Object.keys(state.units || {})
   });
+
+  // When the match is first created the client may briefly receive an empty
+  // game state before setup finishes hydrating the unit map. In that window the
+  // remaining-unit counts are also zero which incorrectly tripped the draw
+  // condition and ended the game immediately. Guard against this by requiring
+  // that the board actually contains units before checking for a draw.
+  if (totalUnits === 0) {
+    return undefined;
+  }
 
   if (remaining['0'] === 0 && remaining['1'] === 0) {
     return { draw: true };

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -12,9 +12,11 @@ export const GridSkirmish: Game<GameState> = {
   setup: setupGame,
   turn: {
     onBegin: (state, ctx) => {
-      resetTurnFlags(state.units, ctx.currentPlayer as PlayerID);
+      if (!ctx) return;
+      const currentPlayer = ctx.currentPlayer as PlayerID;
+      resetTurnFlags(state.units, currentPlayer);
       cleanupSelection(state);
-      pushLog(state, `Player ${Number(ctx.currentPlayer) + 1}'s command phase.`);
+      pushLog(state, `Player ${Number(currentPlayer) + 1}'s command phase.`);
     },
     onEnd: (state) => {
       state.selectedCharacterId = null;

--- a/src/hooks/useMatchManager.ts
+++ b/src/hooks/useMatchManager.ts
@@ -2,9 +2,12 @@ import { useState, useCallback } from 'react';
 import type { PlayerID } from '../types';
 import { GridSkirmish } from '../game';
 
+type SessionRecord = { matchID: string; playerID: PlayerID; credentials: string };
+
 interface UseMatchManagerProps {
   serverUrl: string;
-  storeSession: (session: { matchID: string; playerID: PlayerID; credentials: string } | null) => void;
+  // eslint-disable-next-line no-unused-vars
+  storeSession: (session: SessionRecord | null) => void;
 }
 
 export const useMatchManager = ({ serverUrl, storeSession }: UseMatchManagerProps) => {


### PR DESCRIPTION
## Summary
- prevent Grid Skirmish matches from ending in a draw before units hydrate by requiring a populated board before evaluating victory conditions
- guard turn begin logic against an undefined ctx while setup completes so the server no longer throws during match creation
- centralize stored session typing to satisfy lint checks without changing runtime behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb81300788329a66fb419129c24e4